### PR TITLE
Add resolvers and supporting cast

### DIFF
--- a/app/models/grant_repository.rb
+++ b/app/models/grant_repository.rb
@@ -1,0 +1,8 @@
+# This is a dumb placeholder for what will likely be a thin layer
+# over ActiveRecord -- or we might inject an AR model directly.
+class GrantRepository
+  def grants_for(_,_,_)
+    []
+  end
+end
+

--- a/app/resolvers/credential_resolver.rb
+++ b/app/resolvers/credential_resolver.rb
@@ -1,0 +1,16 @@
+class CredentialResolver
+  attr_reader :action
+
+  def initialize(action)
+    @action = action.to_sym
+  end
+
+  def resolve
+    case action
+    when :edit
+      'permission:edit'
+    when :read
+      'permission:read'
+    end
+  end
+end

--- a/app/resolvers/credential_resolver.rb
+++ b/app/resolvers/credential_resolver.rb
@@ -1,16 +1,26 @@
+require 'permission_mapper'
+
 class CredentialResolver
-  attr_reader :action
-
-  def initialize(action)
-    @action = action.to_sym
+  def initialize(permission_mapper: PermissionMapper.new)
+    @permission_mapper = permission_mapper
   end
 
-  def resolve
-    case action
-    when :edit
-      'permission:edit'
-    when :read
-      'permission:read'
-    end
+  def resolve(action)
+    permissions_for(action) + roles_granting(action)
   end
+
+  private
+
+  def permissions_for(action)
+    perms = permission_mapper.permissions_for(action)
+    perms.map {|p| "permission:#{p}" }
+  end
+
+  def roles_granting(action)
+    roles = permission_mapper.roles_granting(action)
+    roles.map {|r| "role:#{r}" }
+  end
+
+  attr_reader :permission_mapper
+  
 end

--- a/app/resolvers/grant_resolver.rb
+++ b/app/resolvers/grant_resolver.rb
@@ -30,27 +30,27 @@ class GrantResolver
     end
 
     def subjects
-      subject_resolver.resolve
+      subject_resolver.resolve(user)
     end
 
     def credentials
-      credential_resolver.resolve
+      credential_resolver.resolve(action)
     end
 
     def resources
-      resource_resolver.resolve
+      resource_resolver.resolve(target)
     end
 
     def subject_resolver
-      @subject_resolver ||= SubjectResolver.new(user)
+      @subject_resolver ||= SubjectResolver.new
     end
 
     def credential_resolver
-      @credential_resolver ||= CredentialResolver.new(action)
+      @credential_resolver ||= CredentialResolver.new
     end
 
     def resource_resolver
-      @resource_resolver ||= ResourceResolver.new(target)
+      @resource_resolver ||= ResourceResolver.new
     end
 
     def repository

--- a/app/resolvers/grant_resolver.rb
+++ b/app/resolvers/grant_resolver.rb
@@ -1,0 +1,27 @@
+require 'subject_resolver'
+require 'credential_resolver'
+require 'resource_resolver'
+
+class GrantResolver
+  attr_reader :user, :action, :target
+  def initialize(user, action, target)
+    @user = user
+    @action = action
+    @target = target
+  end
+
+  def any?
+    if user.username == 'anna'
+      true
+    else
+      false
+    end
+  end
+
+    # subjects = SubjectResolver.new(user)
+    # ['user:gkostin', 'affiliation:lib-staff']
+    # credentials = CredentialResolver.new(:destroy)
+    # ['permission:destroy']
+    # resources = ResourceResolver.new(listing)
+    # ['listing:12', 'type:listing']
+end

--- a/app/resolvers/grant_resolver.rb
+++ b/app/resolvers/grant_resolver.rb
@@ -3,25 +3,65 @@ require 'credential_resolver'
 require 'resource_resolver'
 
 class GrantResolver
-  attr_reader :user, :action, :target
+  attr_reader :user, :action, :target, :grants
+  attr_writer :subject_resolver, :credential_resolver, :resource_resolver
+
   def initialize(user, action, target)
     @user = user
     @action = action
     @target = target
+    # @grants = [
+    #   ['user:gkostin', 'permission:edit', 'listing:2777'],
+    #   ['role:editor', 'permission:edit', 'type:listing']
+    # ]
   end
 
   def any?
-    if user.username == 'anna'
-      true
-    else
-      false
-    end
+    # Grant.where(subject: subjects, credential: credentials, resource: resources)
+    # SELECT * FROM grants
+    # WHERE subject IN('user:gkostin')
+    # AND credential IN('permission:edit')
+    # AND resource IN('listing:12', 'type:listing')
+
+    grants.any?
   end
 
-    # subjects = SubjectResolver.new(user)
-    # ['user:gkostin', 'affiliation:lib-staff']
-    # credentials = CredentialResolver.new(:destroy)
-    # ['permission:destroy']
-    # resources = ResourceResolver.new(listing)
-    # ['listing:12', 'type:listing']
+  private
+
+    def grants
+      if action == :edit && user.username == 'anna'
+        [['user:anna', 'permission:edit', 'listing:12']]
+      elsif action == :read && user.known?
+        [[subjects.first, 'permission:read', 'listing:12']]
+      else
+        []
+      end
+    end
+
+    def subjects
+      # ['user:gkostin', 'affiliation:lib-staff']
+      subject_resolver.resolve
+    end
+
+    def credentials
+      # ['permission:destroy']
+      credential_resolver.resolve
+    end
+
+    def resources
+      # ['listing:12', 'type:listing']
+      resource_resolver.resolve
+    end
+
+    def subject_resolver
+      @subject_resolver ||= SubjectResolver.new(user)
+    end
+
+    def credential_resolver
+      @credential_resolver ||= CredentialResolver.new(action)
+    end
+
+    def resource_resolver
+      @resource_resolver ||= ResourceResolver.new(target)
+    end
 end

--- a/app/resolvers/permission_mapper.rb
+++ b/app/resolvers/permission_mapper.rb
@@ -1,0 +1,9 @@
+class PermissionMapper
+  def permissions_for(action)
+    [action.to_sym]
+  end
+
+  def roles_granting(action)
+    []
+  end
+end

--- a/app/resolvers/resource_resolver.rb
+++ b/app/resolvers/resource_resolver.rb
@@ -1,22 +1,15 @@
 class ResourceResolver
-  attr_reader :target
-
-  def initialize(target)
-    @target = target
-  end
-
-  def resolve
-    tokens = [entity_token]
-    tokens << type_token
+  def resolve(target)
+    [entity_token(target), type_token(target)]
   end
 
   private
 
-  def entity_token
+  def entity_token(target)
     "#{target.entity_type}:#{target.id}"
   end
 
-  def type_token
+  def type_token(target)
     "type:#{target.entity_type}"
   end
 end

--- a/app/resolvers/resource_resolver.rb
+++ b/app/resolvers/resource_resolver.rb
@@ -1,0 +1,22 @@
+class ResourceResolver
+  attr_reader :target
+
+  def initialize(target)
+    @target = target
+  end
+
+  def resolve
+    tokens = [entity_token]
+    tokens << type_token
+  end
+
+  private
+
+  def entity_token
+    "#{target.entity_type}:#{target.id}"
+  end
+
+  def type_token
+    "type:#{target.entity_type}"
+  end
+end

--- a/app/resolvers/subject_resolver.rb
+++ b/app/resolvers/subject_resolver.rb
@@ -1,0 +1,29 @@
+class SubjectResolver
+  def initialize(user)
+    @user = user
+  end
+
+  def resolve
+    tokens = [user_token]
+    tokens += affiliation_tokens
+    tokens
+  end
+
+  private
+
+  def user_token
+    "user:#{@user.username}"
+  end
+
+  def affiliation_tokens
+    case user_token
+    when 'user:bob'
+      ['affiliation:lib-staff']
+    when 'user:bill'
+      ['affiliation:faculty']
+    when 'user:jane'
+      ['affiliation:lib-staff', 'affiliation:faculty']
+    end
+  end
+
+end

--- a/app/resolvers/subject_resolver.rb
+++ b/app/resolvers/subject_resolver.rb
@@ -23,6 +23,8 @@ class SubjectResolver
       ['affiliation:faculty']
     when 'user:jane'
       ['affiliation:lib-staff', 'affiliation:faculty']
+    else
+      []
     end
   end
 

--- a/app/resolvers/user_directory.rb
+++ b/app/resolvers/user_directory.rb
@@ -1,0 +1,5 @@
+class UserDirectory
+  def attributes_for(user)
+    {}
+  end
+end

--- a/spec/resolvers/credential_resolver_spec.rb
+++ b/spec/resolvers/credential_resolver_spec.rb
@@ -1,26 +1,87 @@
 require 'credential_resolver'
 
-RSpec.describe CredentialResolver do
-  let(:edit) { :edit }
-  let(:read) { :read }
-
-  it "resolves edit to 'permission:edit'" do
-    resolver = CredentialResolver.new(edit)
-    expect(resolver.resolve).to eq 'permission:edit'
+class FakeRoles
+  def permissions_for(action)
+    [action.to_sym]
   end
 
-  it "resolves read to 'permission:read'" do
-    resolver = CredentialResolver.new(read)
-    expect(resolver.resolve).to eq 'permission:read'
-  end
-
-  it "accepts string actions" do
-    resolver = CredentialResolver.new('read')
-    expect(resolver.resolve).to eq 'permission:read'
-  end
-
-  it "accepts symbol actions" do
-    resolver = CredentialResolver.new(:read)
-    expect(resolver.resolve).to eq 'permission:read'
+  def roles_granting(action)
+    case action.to_sym
+    when :edit
+      [:editor, :admin]
+    else
+      []
+    end
   end
 end
+
+class EmptyRoles
+  def permissions_for(action)
+    [action.to_sym]
+  end
+
+  def roles_granting(action)
+    []
+  end
+end
+
+RSpec.describe CredentialResolver do
+  context "when no role permissions are defined" do
+    let(:mapper) { EmptyRoles.new }
+    subject(:resolver) { CredentialResolver.new(permission_mapper: mapper) }
+
+    context "when resolving edit" do
+      subject { resolver.resolve(:edit) }
+
+      it "includes 'permission:edit'" do
+        is_expected.to include('permission:edit')
+      end
+
+      it "does not include any roles" do
+        is_expected.to eq(['permission:edit'])
+      end
+    end
+
+    context "when resolving read" do
+      subject { resolver.resolve(:read) }
+
+      it "includes 'permission:read'" do
+        is_expected.to include('permission:read')
+      end
+
+      it "does not include any roles" do
+        is_expected.to eq(['permission:read'])
+      end
+    end
+
+    it "accepts string actions" do
+      expect(resolver.resolve('read')).to include('permission:read')
+    end
+
+    it "accepts symbol actions" do
+      expect(resolver.resolve(:read)).to include('permission:read')
+    end
+  end
+  
+  context "when editor and admin roles grant edit permission" do
+    let(:mapper)   { FakeRoles.new }
+    let(:resolver) { CredentialResolver.new(permission_mapper: mapper) }
+
+    context "when resolving edit" do
+      subject        { resolver.resolve(:edit) }
+
+      it "includes 'permission:edit'" do
+        is_expected.to include('permission:edit')
+      end
+
+      it "includes 'role:editor'" do
+        is_expected.to include('role:editor')
+      end
+
+      it "includes 'role:admin'" do
+        is_expected.to include('role:admin')
+      end
+    end
+  end
+end
+

--- a/spec/resolvers/credential_resolver_spec.rb
+++ b/spec/resolvers/credential_resolver_spec.rb
@@ -1,0 +1,26 @@
+require 'credential_resolver'
+
+RSpec.describe CredentialResolver do
+  let(:edit) { :edit }
+  let(:read) { :read }
+
+  it "resolves edit to 'permission:edit'" do
+    resolver = CredentialResolver.new(edit)
+    expect(resolver.resolve).to eq 'permission:edit'
+  end
+
+  it "resolves read to 'permission:read'" do
+    resolver = CredentialResolver.new(read)
+    expect(resolver.resolve).to eq 'permission:read'
+  end
+
+  it "accepts string actions" do
+    resolver = CredentialResolver.new('read')
+    expect(resolver.resolve).to eq 'permission:read'
+  end
+
+  it "accepts symbol actions" do
+    resolver = CredentialResolver.new(:read)
+    expect(resolver.resolve).to eq 'permission:read'
+  end
+end

--- a/spec/resolvers/grant_resolver_spec.rb
+++ b/spec/resolvers/grant_resolver_spec.rb
@@ -2,21 +2,46 @@ require 'grant_resolver'
 
 RSpec.describe GrantResolver do
 
-  let(:anna) { double('User', username: 'anna') }
-  let(:katy) { double('User', username: 'katy') }
-  let(:edit) { :edit }
+  let(:anna)    { double('User', username: 'anna', known?: true) }
+  let(:katy)    { double('User', username: 'katy', known?: true) }
+  let(:guest)   { double('User', username: '<guest>', known?: false) }
+  let(:edit)    { :edit }
+  let(:read)    { :read }
   let(:listing) { double('Listing', id: 17, entity_type: 'listing') }
 
-  describe "#any?" do
-
-    it "finds a grant for Anna to edit listing 17" do
+  context "for Anna (known user 1)" do
+    it "finds a grant to edit listing 17" do
       resolver = GrantResolver.new(anna, edit, listing)
       expect(resolver.any?).to be true
     end
 
-    it "does not find a grant for Katy to edit listing 17" do
+    it "finds a grant to read listing 17" do
+      resolver = GrantResolver.new(anna, read, listing)
+      expect(resolver.any?).to be true
+    end
+  end
+
+  context "for Katy (known user 2)" do
+    it "does not find a grant to edit listing 17" do
       resolver = GrantResolver.new(katy, edit, listing)
       expect(resolver.any?).to be false
+    end
+
+    it "finds a grant to read listing 17" do
+      resolver = GrantResolver.new(katy, read, listing)
+      expect(resolver.any?).to be true
+    end
+  end
+
+  context "for a guest user" do
+    it "does not find any grants to read listing 17" do
+      resolver = GrantResolver.new(guest, read, listing)
+      expect(resolver.any?).to eq false
+    end
+
+    it "does not find any grants to edit listing 17" do
+      resolver = GrantResolver.new(guest, read, listing)
+      expect(resolver.any?).to eq false
     end
   end
 

--- a/spec/resolvers/grant_resolver_spec.rb
+++ b/spec/resolvers/grant_resolver_spec.rb
@@ -1,0 +1,23 @@
+require 'grant_resolver'
+
+RSpec.describe GrantResolver do
+
+  let(:anna) { double('User', username: 'anna') }
+  let(:katy) { double('User', username: 'katy') }
+  let(:edit) { :edit }
+  let(:listing) { double('Listing', id: 17, entity_type: 'listing') }
+
+  describe "#any?" do
+
+    it "finds a grant for Anna to edit listing 17" do
+      resolver = GrantResolver.new(anna, edit, listing)
+      expect(resolver.any?).to be true
+    end
+
+    it "does not find a grant for Katy to edit listing 17" do
+      resolver = GrantResolver.new(katy, edit, listing)
+      expect(resolver.any?).to be false
+    end
+  end
+
+end

--- a/spec/resolvers/grant_resolver_spec.rb
+++ b/spec/resolvers/grant_resolver_spec.rb
@@ -21,17 +21,17 @@ RSpec.describe GrantResolver do
   let(:action)  { :read }
   let(:target)  { listing }
 
-  let(:subject_resolver)    { double('SubjectResolver', resolve: []) }
-  let(:anna_resolver)       { double('SubjectResolver', resolve: ['user:anna', 'account-type:umich', 'affiliation:lib-staff']) }
-  let(:katy_resolver)       { double('SubjectResolver', resolve: ['user:katy', 'account-type:umich', 'affiliation:faculty']) }
-  let(:guest_resolver)      { double('SubjectResolver', resolve: ['account-type:guest']) }
+  let(:subject_resolver)    { instance_double('SubjectResolver', resolve: []) }
+  let(:anna_resolver)       { instance_double('SubjectResolver', resolve: ['user:anna', 'account-type:umich', 'affiliation:lib-staff']) }
+  let(:katy_resolver)       { instance_double('SubjectResolver', resolve: ['user:katy', 'account-type:umich', 'affiliation:faculty']) }
+  let(:guest_resolver)      { instance_double('SubjectResolver', resolve: ['account-type:guest']) }
 
-  let(:credential_resolver) { double('CredentialResolver', resolve: []) }
-  let(:read_resolver)       { double('CredentialResolver', resolve: ['permission:read']) }
-  let(:edit_resolver)       { double('CredentialResolver', resolve: ['permission:edit']) }
+  let(:credential_resolver) { instance_double('CredentialResolver', resolve: []) }
+  let(:read_resolver)       { instance_double('CredentialResolver', resolve: ['permission:read']) }
+  let(:edit_resolver)       { instance_double('CredentialResolver', resolve: ['permission:edit']) }
 
-  let(:resource_resolver)   { double('ResourceResolver', resolve: []) }
-  let(:listing_resolver)    { double('ResourceResolver', resolve: ['listing:17', 'type:listing']) }
+  let(:resource_resolver)   { instance_double('ResourceResolver', resolve: []) }
+  let(:listing_resolver)    { instance_double('ResourceResolver', resolve: ['listing:17', 'type:listing']) }
 
   subject(:resolver) {
     GrantResolver.new(user, action, target).tap do |resolver|

--- a/spec/resolvers/permission_mapper_spec.rb
+++ b/spec/resolvers/permission_mapper_spec.rb
@@ -1,0 +1,29 @@
+require 'permission_mapper'
+
+RSpec.describe PermissionMapper do
+  subject(:mapper) { PermissionMapper.new }
+
+  describe "#roles_granting" do
+    it "expands :read to no roles" do
+      expect(mapper.roles_granting(:read)).to eq []
+    end
+  end
+
+  describe "#permissions_for" do
+    it "maps :read as :read" do
+      expect(mapper.permissions_for(:read)).to eq [:read]
+    end
+
+    it "maps 'read' as :read" do
+      expect(mapper.permissions_for('read')).to eq [:read]
+    end
+
+    it "maps :edit as :edit" do
+      expect(mapper.permissions_for(:edit)).to eq [:edit]
+    end
+
+    it "maps 'edit' as :edit" do
+      expect(mapper.permissions_for('edit')).to eq [:edit]
+    end
+  end
+end

--- a/spec/resolvers/resource_resolver_spec.rb
+++ b/spec/resolvers/resource_resolver_spec.rb
@@ -1,33 +1,30 @@
 require 'resource_resolver'
 
 RSpec.describe ResourceResolver do
-  let(:listing1) { double('Listing', id: 12, entity_type: 'listing') }
-  let(:listing2) { double('Listing', id: 13, entity_type: 'listing') }
+  let(:listing1)  { double('Listing', id: 12, entity_type: 'listing') }
+  let(:listing2)  { double('Listing', id: 13, entity_type: 'listing') }
   let(:newspaper) { double('Newspaper', id: 8, entity_type: 'newspaper') }
 
+  subject(:resolver) { ResourceResolver.new }
+
   it "resolves a listing to its entity token" do
-    resolver = ResourceResolver.new(listing1)
-    expect(resolver.resolve).to include('listing:12')
+    expect(resolver.resolve(listing1)).to include('listing:12')
   end
 
   it "resolves another listing to its entity token" do
-    resolver = ResourceResolver.new(listing2)
-    expect(resolver.resolve).to include('listing:13')
+    expect(resolver.resolve(listing2)).to include('listing:13')
   end
 
   it "resolves a listing to its type token" do
-    resolver = ResourceResolver.new(listing1)
-    expect(resolver.resolve).to include('type:listing')
+    expect(resolver.resolve(listing1)).to include('type:listing')
   end
 
   it "resolves a newspaper to its entity token" do
-    resolver = ResourceResolver.new(newspaper)
-    expect(resolver.resolve).to include('newspaper:8')
+    expect(resolver.resolve(newspaper)).to include('newspaper:8')
   end
 
   it "resolves a newspaper to its type token" do
-    resolver = ResourceResolver.new(newspaper)
-    expect(resolver.resolve).to include('type:newspaper')
+    expect(resolver.resolve(newspaper)).to include('type:newspaper')
   end
 
 end

--- a/spec/resolvers/resource_resolver_spec.rb
+++ b/spec/resolvers/resource_resolver_spec.rb
@@ -1,0 +1,33 @@
+require 'resource_resolver'
+
+RSpec.describe ResourceResolver do
+  let(:listing1) { double('Listing', id: 12, entity_type: 'listing') }
+  let(:listing2) { double('Listing', id: 13, entity_type: 'listing') }
+  let(:newspaper) { double('Newspaper', id: 8, entity_type: 'newspaper') }
+
+  it "resolves a listing to its entity token" do
+    resolver = ResourceResolver.new(listing1)
+    expect(resolver.resolve).to include('listing:12')
+  end
+
+  it "resolves another listing to its entity token" do
+    resolver = ResourceResolver.new(listing2)
+    expect(resolver.resolve).to include('listing:13')
+  end
+
+  it "resolves a listing to its type token" do
+    resolver = ResourceResolver.new(listing1)
+    expect(resolver.resolve).to include('type:listing')
+  end
+
+  it "resolves a newspaper to its entity token" do
+    resolver = ResourceResolver.new(newspaper)
+    expect(resolver.resolve).to include('newspaper:8')
+  end
+
+  it "resolves a newspaper to its type token" do
+    resolver = ResourceResolver.new(newspaper)
+    expect(resolver.resolve).to include('type:newspaper')
+  end
+
+end

--- a/spec/resolvers/subject_resolver_spec.rb
+++ b/spec/resolvers/subject_resolver_spec.rb
@@ -1,31 +1,44 @@
 require 'subject_resolver'
 
+class FakeDirectory
+  def attributes_for(user)
+    case user.username
+    when 'bill'
+      { account_type: 'umich', affiliations: ['faculty'] }
+    when 'bob'
+      { account_type: 'umich', affiliations: ['lib-staff'] }
+    when 'jane'
+      { account_type: 'umich', affiliations: ['faculty', 'lib-staff'] }
+    else
+      { }
+    end
+  end
+end
+
 RSpec.describe SubjectResolver do
 
   context "with a known user" do
-    let(:bill)  { double('User', username: 'bill',    known?: true) }
-    let(:bob)   { double('User', username: 'bob',     known?: true) }
-    let(:jane)  { double('User', username: 'jane',    known?: true) }
-    let(:guest) { double('User', username: '<guest>', known?: false) }
+    let(:bill)  { double('User', username: 'bill') }
+    let(:bob)   { double('User', username: 'bob') }
+    let(:jane)  { double('User', username: 'jane') }
+    let(:guest) { double('User', username: '<guest>') }
+    let(:directory)    { FakeDirectory.new }
+    subject(:resolver) { SubjectResolver.new(directory: directory) }
 
-    it "resolves User `bill`'s token" do
-      resolver = SubjectResolver.new(bill)
-      expect(resolver.resolve).to eq ['user:bill', 'affiliation:faculty']
+    it "resolves User `bill`'s tokens" do
+      expect(resolver.resolve(bill)).to include('account-type:umich', 'user:bill', 'affiliation:faculty')
     end
 
-    it "resolves User `bob`'s token" do
-      resolver = SubjectResolver.new(bob)
-      expect(resolver.resolve).to eq ['user:bob', 'affiliation:lib-staff']
+    it "resolves User `bob`'s tokens" do
+      expect(resolver.resolve(bob)).to include('account-type:umich', 'user:bob', 'affiliation:lib-staff')
     end
 
-    it "resolves User `jane`'s token" do
-      resolver = SubjectResolver.new(jane)
-      expect(resolver.resolve).to eq ['user:jane', 'affiliation:lib-staff', 'affiliation:faculty']
+    it "resolves User `jane`'s tokens" do
+      expect(resolver.resolve(jane)).to include('account-type:umich', 'user:jane', 'affiliation:lib-staff', 'affiliation:faculty')
     end
 
     it "resolves guest user's tokens" do
-      resolver = SubjectResolver.new(guest)
-      expect(resolver.resolve).to eq ['user:<guest>']
+      expect(resolver.resolve(guest)).to include('account-type:guest', 'user:<guest>')
     end
   end
 end

--- a/spec/resolvers/subject_resolver_spec.rb
+++ b/spec/resolvers/subject_resolver_spec.rb
@@ -1,0 +1,25 @@
+require 'subject_resolver'
+
+RSpec.describe SubjectResolver do
+
+  context "with a known user" do
+    let(:bill) { double('User', username: 'bill', known?: true) }
+    let(:bob)  { double('User', username: 'bob', known?: true) }
+    let(:jane) { double('User', username: 'jane', known?: true) }
+
+    it "resolves User `bill`'s token" do
+      resolver = SubjectResolver.new(bill)
+      expect(resolver.resolve).to eq ['user:bill', 'affiliation:faculty']
+    end
+
+    it "resolves User `bob`'s token" do
+      resolver = SubjectResolver.new(bob)
+      expect(resolver.resolve).to eq ['user:bob', 'affiliation:lib-staff']
+    end
+
+    it "resolves User `jane`'s token" do
+      resolver = SubjectResolver.new(jane)
+      expect(resolver.resolve).to eq ['user:jane', 'affiliation:lib-staff', 'affiliation:faculty']
+    end
+  end
+end

--- a/spec/resolvers/subject_resolver_spec.rb
+++ b/spec/resolvers/subject_resolver_spec.rb
@@ -3,9 +3,10 @@ require 'subject_resolver'
 RSpec.describe SubjectResolver do
 
   context "with a known user" do
-    let(:bill) { double('User', username: 'bill', known?: true) }
-    let(:bob)  { double('User', username: 'bob', known?: true) }
-    let(:jane) { double('User', username: 'jane', known?: true) }
+    let(:bill)  { double('User', username: 'bill',    known?: true) }
+    let(:bob)   { double('User', username: 'bob',     known?: true) }
+    let(:jane)  { double('User', username: 'jane',    known?: true) }
+    let(:guest) { double('User', username: '<guest>', known?: false) }
 
     it "resolves User `bill`'s token" do
       resolver = SubjectResolver.new(bill)
@@ -20,6 +21,11 @@ RSpec.describe SubjectResolver do
     it "resolves User `jane`'s token" do
       resolver = SubjectResolver.new(jane)
       expect(resolver.resolve).to eq ['user:jane', 'affiliation:lib-staff', 'affiliation:faculty']
+    end
+
+    it "resolves guest user's tokens" do
+      resolver = SubjectResolver.new(guest)
+      expect(resolver.resolve).to eq ['user:<guest>']
     end
   end
 end

--- a/spec/resolvers/user_directory_spec.rb
+++ b/spec/resolvers/user_directory_spec.rb
@@ -1,0 +1,12 @@
+require 'user_directory'
+
+RSpec.describe UserDirectory do
+  describe "#attributes_for" do
+    let(:user) { double('User') }
+    subject(:directory) { UserDirectory.new }
+
+    it "gives an empty attribute hash" do
+      expect(directory.attributes_for(user)).to eq({})
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,15 @@ if coverage_needed?
   end
 end
 
+require 'pathname'
+app_root = Pathname.new(File.dirname(__FILE__)).parent
+%w[
+  app/models
+  app/resolvers
+].each do |path|
+  $LOAD_PATH.unshift app_root + path
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
This brings in four "resolvers", one each for Subjects (agents, maybe in need of rename), Credentials, Resources, and Grants.

There are two helper abstractions introduced here as well: a UserDirectory and a PermissionMapper. These are here to clarify and separate the core resolution/grant workflow from environmental/application concerns like finding groups and attributes for a user or how actions are mapped to permission names and which roles would impute those permissions. The resolvers are only concerned with translating an object to tokens, not the external semantics, which can vary.

The GrantResolver will probably be renamed, since it has a different purpose and interface. It relies on the resolvers (all of which resolve an object to a set of tokens) to check whether there are satisfactory grants. Similarly, the tokens may be changed to pairs or an object (from the string representation of `<scope>:<identifier>`) except for display purposes. There are likely persistence, housekeeping, and reporting concerns at the scope level aside from the identifier level, which would be facilitated by keeping them separate (and not distributing string logic throughout the code).