### PR TITLE
Add support for auto-presentation of objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,8 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+
+###
+
+gem 'canister'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.1.0)
+    canister (0.9.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     coveralls (0.7.1)
@@ -239,6 +240,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  canister
   coveralls
   debase
   factory_bot_rails (~> 4.8.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+    def present(object)
+      Services.presenters[object, current_user, view_context]
+    end
+
     def auto_login(user)
       session[:user_id] = user.id
     end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -34,7 +34,8 @@ class ListingsController < ApplicationController
 
   def index
     policy = ListingsPolicy.new(current_user)
-    @listings = ListingsPresenter.new(policy, view_context)
+    # @listings = ListingsPresenter.new(policy, view_context)
+    @listings = present(policy.base_scope)
   end
 
   def new
@@ -45,6 +46,8 @@ class ListingsController < ApplicationController
 
   def show
     @policy.authorize! :show?
+    # @listing = ListingPresenter.new(@policy, view_context)
+    @listing = present(@policy.resource)
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,4 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def user_display_name_link(user)
-    if user.known?
-      link_to user.display_name, user
-    else
-      user.display_name
-    end
-  end
 end

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CollectionPresenter
+  include Enumerable
+
+  def initialize(policy, view, presenter_factory: Services.presenters)
+    @policy = policy
+    @view   = view
+    @presenter_factory = presenter_factory
+  end
+
+  def each
+    resources.each { |resource| yield resource }
+  end
+
+  def empty?
+    resources.empty?
+  end
+
+  protected
+
+    def resources
+      @resources ||= policy.resolve.map do |resource|
+        present(resource)
+      end
+    end
+
+    def present(resource)
+      presenter_factory[resource, policy.user, view]
+    end
+
+    attr_reader :policy, :view, :presenter_factory
+end

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,33 +1,9 @@
 # frozen_string_literal: true
 
-class CollectionPresenter
-  include Enumerable
-
-  def initialize(policy, view, presenter_factory: Services.presenters)
-    @policy = policy
-    @view   = view
-    @presenter_factory = presenter_factory
-  end
-
-  def each
-    resources.each { |resource| yield resource }
-  end
-
-  def empty?
-    resources.empty?
-  end
-
+# Set up our base presenter; no extensions to Vizier for now
+class CollectionPresenter < Vizier::CollectionPresenter
   protected
-
-    def resources
-      @resources ||= policy.resolve.map do |resource|
-        present(resource)
-      end
+    def presenter_factory
+      Services.presenters
     end
-
-    def present(resource)
-      presenter_factory[resource, policy.user, view]
-    end
-
-    attr_reader :policy, :view, :presenter_factory
 end

--- a/app/presenters/listing_presenter.rb
+++ b/app/presenters/listing_presenter.rb
@@ -1,16 +1,7 @@
 # frozen_string_literal: true
 
-class ListingPresenter < SimpleDelegator
-  extend Forwardable
-
+class ListingPresenter < ResourcePresenter
   delegate [:edit?, :destroy?] => :policy
-
-  def initialize(listing, policy, view)
-    @listing = listing
-    @policy  = policy
-    @view    = view
-    __setobj__ @listing
-  end
 
   def link_or_title
     if policy.show?
@@ -24,7 +15,11 @@ class ListingPresenter < SimpleDelegator
     view.link_to 'Show', listing if policy.show?
   end
 
+  def owner
+    present(listing.owner)
+  end
+
   private
 
-    attr_reader :listing, :policy, :view
+    alias_method :listing, :resource
 end

--- a/app/presenters/listings_presenter.rb
+++ b/app/presenters/listings_presenter.rb
@@ -1,32 +1,18 @@
 # frozen_string_literal: true
 
-class ListingsPresenter
-  include Enumerable
-
-  def initialize(policy, view)
-    @policy   = policy
-    @view     = view
-  end
-
-  def each
-    listings.each { |l| yield l }
-  end
-
-  def empty?
-    listings.empty?
-  end
-
+class ListingsPresenter < CollectionPresenter
   def new?
     policy.new?
   end
 
   private
 
-    def listings
-      @listings ||= policy.resolve.map do |listing|
-        ListingPresenter.new(listing, policy.for(listing), view)
-      end
-    end
+    # `present` can be implemented to use something other than the default
+    # presenter and policy resolution.
+    #
+    # def present(resource)
+    #   SpecializedListingPresenter.new(policy.for(listing), view)
+    # end
 
-    attr_reader :policy, :view
+    alias_method :listings, :resources
 end

--- a/app/presenters/resource_presenter.rb
+++ b/app/presenters/resource_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ResourcePresenter < SimpleDelegator
+  extend Forwardable
+
+  def initialize(policy, view, presenter_factory: Services.presenters)
+    @policy = policy
+    @view   = view
+    @presenter_factory = presenter_factory
+    __setobj__ policy.resource
+  end
+
+  private
+
+    def resource
+      policy.resource
+    end
+
+    def present(object)
+      presenter_factory[object, policy.user, view]
+    end
+
+    attr_reader :policy, :view, :presenter_factory
+end

--- a/app/presenters/resource_presenter.rb
+++ b/app/presenters/resource_presenter.rb
@@ -1,24 +1,9 @@
 # frozen_string_literal: true
 
-class ResourcePresenter < SimpleDelegator
-  extend Forwardable
-
-  def initialize(policy, view, presenter_factory: Services.presenters)
-    @policy = policy
-    @view   = view
-    @presenter_factory = presenter_factory
-    __setobj__ policy.resource
-  end
-
-  private
-
-    def resource
-      policy.resource
+# Set up our base presenter; no extensions to Vizier for now
+class ResourcePresenter < Vizier::ResourcePresenter
+  protected
+    def presenter_factory
+      Services.presenters
     end
-
-    def present(object)
-      presenter_factory[object, policy.user, view]
-    end
-
-    attr_reader :policy, :view, :presenter_factory
 end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserPresenter < ResourcePresenter
+  def display_name_link
+    view.link_to_if known?, display_name, user
+  end
+
+  private
+
+    alias_method :user, :resource
+end

--- a/app/views/listings/index.html.slim
+++ b/app/views/listings/index.html.slim
@@ -17,7 +17,7 @@ h1 Office Gear Swap Meet!
         - @listings.each do |listing|
           tr
             td = listing.link_or_title
-            td = user_display_name_link(listing.owner)
+            td = listing.owner.display_name_link
 
             td = listing.show_link
             td = link_to 'Edit', edit_listing_path(listing) if listing.edit?

--- a/app/views/listings/show.html.slim
+++ b/app/views/listings/show.html.slim
@@ -10,15 +10,15 @@ p
   = @listing.body
 p
   strong Owner:&nbsp
-  = user_display_name_link(@listing.owner)
+  = @listing.owner.display_name_link
 p
-/  strong Newspaper:&nbsp
-/  = link_to @listing.newspaper&.display_name, newspaper_path(@listing.newspaper) if @listing.newspaper
+  strong Category:&nbsp
+  = @listing.category.title
 
-- if @policy.edit?
+- if @listing.edit?
   =<> link_to 'Edit', edit_listing_path(@listing)
   '|
-- if @policy.destroy?
+- if @listing.destroy?
   =<> link_to 'Delete', @listing, data: { confirm: 'Are you sure?' }, method: :delete
   '|
 =<> link_to 'Back', listings_path

--- a/app/vizier/vizier.rb
+++ b/app/vizier/vizier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# TODO: turn this into real gem layout
+require_relative 'vizier/null_presenter'
+require_relative 'vizier/read_only_policy'
+
+require_relative 'vizier/presenter_config'
+require_relative 'vizier/caching_presenter_config'
+require_relative 'vizier/default_presenter_config'
+
+require_relative 'vizier/collection_presenter'
+require_relative 'vizier/resource_presenter'
+require_relative 'vizier/presenter_factory'
+
+module Vizier
+  VERSION = '0.1.0'
+end

--- a/app/vizier/vizier/caching_presenter_config.rb
+++ b/app/vizier/vizier/caching_presenter_config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'presenter_config'
+
 # A presenter configuration that caches the type lookup
 #
 # For development use reloading is convenient, but in production

--- a/app/vizier/vizier/caching_presenter_config.rb
+++ b/app/vizier/vizier/caching_presenter_config.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# A presenter configuration that caches the type lookup
+#
+# For development use reloading is convenient, but in production
+# the constants should not be redefined. We cache them here to
+# avoid repeated global lookups.
+module Vizier
+  class CachingPresenterConfig < PresenterConfig
+    def type
+      @type ||= super
+    end
+
+    def presenter
+      @presenter ||= super
+    end
+
+    def policy
+      @policy ||= super
+    end
+  end
+end

--- a/app/vizier/vizier/collection_presenter.rb
+++ b/app/vizier/vizier/collection_presenter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Vizier
+  class CollectionPresenter
+    include Enumerable
+
+    def initialize(policy, view, presenter_factory: PresenterFactory.new)
+      @policy = policy
+      @view   = view
+      @presenter_factory = presenter_factory
+    end
+
+    def each
+      resources.each { |resource| yield resource }
+    end
+
+    def empty?
+      resources.empty?
+    end
+
+    protected
+
+      def resources
+        @resources ||= policy.resolve.map do |resource|
+          present(resource)
+        end
+      end
+
+      def present(resource)
+        presenter_factory[resource, policy.user, view]
+      end
+
+      attr_reader :policy, :view, :presenter_factory
+  end
+end

--- a/app/vizier/vizier/default_presenter_config.rb
+++ b/app/vizier/vizier/default_presenter_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Vizier
+  class DefaultPresenterConfig
+    attr_reader :config_type
+
+    def initialize(config_type)
+      @config_type = config_type
+    end
+
+    def for(type)
+      config_type.new(type, NullPresenter, ReadOnlyPolicy)
+    end
+  end
+end

--- a/app/vizier/vizier/null_presenter.rb
+++ b/app/vizier/vizier/null_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Simple pass-through presenter that serves as a default.
+#
+# We may want to use something other than `.new` so this
+# can actually return the object rather than a new instance
+# of itself.
+module Vizier
+  class NullPresenter < SimpleDelegator
+    def initialize(object, *)
+      __setobj__ object
+    end
+  end
+end

--- a/app/vizier/vizier/presenter_config.rb
+++ b/app/vizier/vizier/presenter_config.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Mapping for a given type to presenter and policy types
+#
+# This configuration does not cache the constant lookups,
+# so it supports reloading of the types in development.
+# The CachingPresenterConfig should be used in production.
+module Vizier
+  class PresenterConfig
+    def initialize(type, presenter, policy)
+      @type_name      = type.to_s
+      @presenter_name = presenter.to_s
+      @policy_name    = policy.to_s
+    end
+
+    def present(object, user, view)
+      presenter.new(policy.new(user, object), view)
+    end
+
+    def type
+      Object.const_get(@type_name)
+    end
+
+    def presenter
+      Object.const_get(@presenter_name)
+    end
+
+    def policy
+      Object.const_get(@policy_name)
+    end
+  end
+end

--- a/app/vizier/vizier/presenter_factory.rb
+++ b/app/vizier/vizier/presenter_factory.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Factory for locating and creating a presenter based on an object's type
+module Vizier
+  class PresenterFactory
+    def initialize(
+        presenter_map = {},
+        config_type: PresenterConfig,
+        default_config: DefaultPresenterConfig.new(config_type))
+
+      @config_type    = config_type
+      @default_config = default_config
+
+      @configs = Hash.new do |configs, type|
+        default_config.for(type, config_type)
+      end
+
+      presenter_map.each do |type, config|
+        @configs[type.to_s] = config_type.new(type, config.first, config.last)
+      end
+    end
+
+    def [](object, user, view)
+      configs[object.class.to_s].present(object, user, view)
+    end
+
+    private
+
+      attr_accessor :configs, :config_type, :default_config
+  end
+end

--- a/app/vizier/vizier/presenter_factory.rb
+++ b/app/vizier/vizier/presenter_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'presenter_config'
+require_relative 'default_presenter_config'
+
 # Factory for locating and creating a presenter based on an object's type
 module Vizier
   class PresenterFactory
@@ -12,7 +15,7 @@ module Vizier
       @default_config = default_config
 
       @configs = Hash.new do |configs, type|
-        default_config.for(type, config_type)
+        default_config.for(type)
       end
 
       presenter_map.each do |type, config|

--- a/app/vizier/vizier/read_only_policy.rb
+++ b/app/vizier/vizier/read_only_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This is a basic/dummy policy that can be used as a default.
+# There is no hard dependency on Checkpoint, but it has the same
+# interface as a minimal resource policy.
+module Vizier
+  class ReadOnlyPolicy
+    attr_reader :user, :resource
+
+    def initialize(user, resource)
+      @user     = user
+      @resource = resource
+    end
+
+    def show?
+      true
+    end
+
+    def authorize!(action, message = nil)
+      raise NotAuthorizedError.new(message) unless send(action)
+    end
+  end
+end

--- a/app/vizier/vizier/resource_presenter.rb
+++ b/app/vizier/vizier/resource_presenter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'presenter_factory'
+
 module Vizier
   class ResourcePresenter < SimpleDelegator
     extend Forwardable
@@ -11,7 +13,7 @@ module Vizier
       __setobj__ policy.resource
     end
 
-    private
+    protected
 
       def resource
         policy.resource

--- a/app/vizier/vizier/resource_presenter.rb
+++ b/app/vizier/vizier/resource_presenter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Vizier
+  class ResourcePresenter < SimpleDelegator
+    extend Forwardable
+
+    def initialize(policy, view, presenter_factory: PresenterFactory.new)
+      @policy = policy
+      @view   = view
+      @presenter_factory = presenter_factory
+      __setobj__ policy.resource
+    end
+
+    private
+
+      def resource
+        policy.resource
+      end
+
+      def present(object)
+        presenter_factory[object, policy.user, view]
+      end
+
+      attr_reader :policy, :view, :presenter_factory
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative '../app/vizier/vizier'
+
 module Swapmeet
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -31,6 +33,8 @@ module Swapmeet
     config.generators.system_tests = nil
 
     # Add presenters to autoload paths
-    config.autoload_paths += %W[#{config.root}/app/presenters]
+    config.autoload_paths += %W[#{config.root}/app/presenters #{config.root}/app/vizier]
+
+    config.presenter_config = ::Vizier::PresenterConfig
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.presenter_config = ::Vizier::CachingPresenterConfig
 end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,71 +1,12 @@
 # frozen_string_literal: true
 
+PRESENTERS = {
+  Listing => [ListingPresenter, ListingPolicy],
+  User    => [UserPresenter, Vizier::ReadOnlyPolicy],
+  'Listing::ActiveRecord_Relation' => [ListingsPresenter, ListingsPolicy],
+}
+
 Services = Canister.new
-
-class NullPresenter < SimpleDelegator
-  def initialize(object, *)
-    __setobj__ object
-  end
-end
-
-class ReadOnlyPolicy < ResourcePolicy
-  def show?
-    true
-  end
-end
-
-class PresenterConfig
-  def initialize(type, presenter, policy)
-    @type_name      = type.to_s
-    @presenter_name = presenter.to_s
-    @policy_name    = policy.to_s
-  end
-
-  def present(object, user, view)
-    presenter.new(policy.new(user, object), view)
-  end
-
-  def type
-    # Cache these, but only in production... Old classes persist over reload.
-    # @type ||= Object.const_get(@type_name)
-    Object.const_get(@type_name)
-  end
-
-  def presenter
-    # @presenter ||= Object.const_get(@presenter_name)
-    Object.const_get(@presenter_name)
-  end
-
-  def policy
-    # @policy ||= Object.const_get(@policy_name)
-    Object.const_get(@policy_name)
-  end
-end
-
-class Presenters
-  PRESENTERS = {
-    Listing => [ListingPresenter, ListingPolicy],
-    User    => [UserPresenter, ReadOnlyPolicy],
-    'Listing::ActiveRecord_Relation' => [ListingsPresenter, ListingsPolicy],
-  }
-
-  def initialize
-    @configs = Hash.new do |presenters, type|
-      PresenterConfig.new(type, NullPresenter, ReadOnlyPolicy)
-    end
-
-    PRESENTERS.each do |type, config|
-      @configs[type.to_s] = PresenterConfig.new(type, config.first, config.last)
-    end
-  end
-
-  def [](object, user, view)
-    configs[object.class.to_s].present(object, user, view)
-  end
-
-  private
-
-    attr_accessor :configs
-end
-
-Services.register(:presenters) { Presenters.new }
+Services.register(:presenters) {
+  Vizier::PresenterFactory.new(PRESENTERS, config_type: Rails.configuration.presenter_config)
+}

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+Services = Canister.new
+
+class NullPresenter < SimpleDelegator
+  def initialize(object, *)
+    __setobj__ object
+  end
+end
+
+class ReadOnlyPolicy < ResourcePolicy
+  def show?
+    true
+  end
+end
+
+class PresenterConfig
+  def initialize(type, presenter, policy)
+    @type_name      = type.to_s
+    @presenter_name = presenter.to_s
+    @policy_name    = policy.to_s
+  end
+
+  def present(object, user, view)
+    presenter.new(policy.new(user, object), view)
+  end
+
+  def type
+    # Cache these, but only in production... Old classes persist over reload.
+    # @type ||= Object.const_get(@type_name)
+    Object.const_get(@type_name)
+  end
+
+  def presenter
+    # @presenter ||= Object.const_get(@presenter_name)
+    Object.const_get(@presenter_name)
+  end
+
+  def policy
+    # @policy ||= Object.const_get(@policy_name)
+    Object.const_get(@policy_name)
+  end
+end
+
+class Presenters
+  PRESENTERS = {
+    Listing => [ListingPresenter, ListingPolicy],
+    User    => [UserPresenter, ReadOnlyPolicy],
+    'Listing::ActiveRecord_Relation' => [ListingsPresenter, ListingsPolicy],
+  }
+
+  def initialize
+    @configs = Hash.new do |presenters, type|
+      PresenterConfig.new(type, NullPresenter, ReadOnlyPolicy)
+    end
+
+    PRESENTERS.each do |type, config|
+      @configs[type.to_s] = PresenterConfig.new(type, config.first, config.last)
+    end
+  end
+
+  def [](object, user, view)
+    configs[object.class.to_s].present(object, user, view)
+  end
+
+  private
+
+    attr_accessor :configs
+end
+
+Services.register(:presenters) { Presenters.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,8 @@ end
 if coverage_needed?
   require 'coveralls'
   Coveralls.wear!('rails') do
-    add_filter 'config'
-    add_filter 'spec'
+    # add_filter 'config'
+    # add_filter 'spec'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ app_root = Pathname.new(File.dirname(__FILE__)).parent
 %w[
   app/models
   app/resolvers
+  app/vizier
 ].each do |path|
   $LOAD_PATH.unshift app_root + path
 end

--- a/spec/support/presenter_config_fakes.rb
+++ b/spec/support/presenter_config_fakes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# These are fakes for testing presenter configs.
+# They're set up here, rather than individual tests because of the funny
+# business of const_get, auto reloading, and redefining constants with Struct.
+# A require makes sure that these are available to both the reloading and
+# caching configs without throwing warnings.
+
+class FakeType; end
+FakePresenter = Struct.new(:policy, :view)
+FakePolicy = Struct.new(:user, :object)
+
+class OtherFakeType; end
+OtherFakePresenter = Struct.new(:policy, :view)
+OtherFakePolicy = Struct.new(:user, :object)

--- a/spec/support/resource_presenter_fakes.rb
+++ b/spec/support/resource_presenter_fakes.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'vizier/presenter_factory'
+require 'vizier/resource_presenter'
+
+# Example of inheriting to take advantage of auto-presentation
+
+# This would be some resource/model class; these are just fakes.
+class SomeResource
+  attr_reader :name, :other_resource
+
+  def initialize(name, other_resource)
+    @name = name
+    @other_resource = other_resource
+  end
+end
+
+# Another resource/model, here to demonstrate auto-presentation of associated
+# objects.
+class OtherResource
+  attr_reader :title
+
+  def initialize(title)
+    @title = title
+  end
+end
+
+# This would be a resource-oriented policy (governing CRUD/REST actions)
+# It would probably inherit from a convenience class for delegating.
+# For this example, creating a SomeResource is allowed unconditionally.
+class SomeResourcePolicy
+  attr_reader :user, :resource
+
+  def initialize(user, resource)
+    @user = user
+    @resource = resource
+  end
+
+  def create?
+    true
+  end
+end
+
+# This would be the policy for another type. In this example editing an
+# OtherResource is prohibited unconditionally.
+class OtherResourcePolicy
+  attr_reader :user, :resource
+
+  def initialize(user, resource)
+    @user = user
+    @resource = resource
+  end
+
+  def edit?
+    false
+  end
+end
+
+# This would be the base resource presenter for your application.
+# It provides your configured factory (mapping types to presenters/policies)
+# to all inheriting presenters for auto-presentation of associated objects.
+# The factory should be built in an initializer and made available with
+# a service locator (class method) or IoC container.
+# This base class is similar in purpose to ApplicationRecord.
+class AppResourcePresenter < Vizier::ResourcePresenter
+  protected
+
+    def presenter_factory
+      FakePresenterFactory.instance
+    end
+end
+
+# This would be a specific presenter for the resource type.
+# Note that it calls `present` with the associated object, which invokes
+# the factory for presenting the object according to the default mapping,
+# without needing to know the types or constructing the presenter/policy.
+class SomeResourcePresenter < AppResourcePresenter
+  def name
+    resource.name.upcase
+  end
+
+  def other_resource
+    present(resource.other_resource)
+  end
+
+  # Delegate permission checks to the policy
+  def create?
+    policy.create?
+  end
+end
+
+class OtherResourcePresenter < AppResourcePresenter
+  def short_title
+    title[0..5] + '...'
+  end
+
+  # Delegate permission checks to the policy
+  def edit?
+    policy.edit?
+  end
+end
+
+# This is the fake service locator. This would work in a real app, but using
+# a minimal IoC container like Canister is recommended.
+module FakePresenterFactory
+  # This is the mapping of types to the presenters and policies that should be
+  # used by default. The PRESENTERS name is not special; it would probably be
+  # defined in an initializer or Ruby config file and passed to the
+  # PresenterFactory constructor. A naming convention of appending Presenter or
+  # Policy after the resource type name is followed here, but need not be. If an
+  # object's class (or its string equivalent) is not mapped, the fall-through
+  # default is to use a Vizier::NullPresenter and a Vizier::ReadOnlyPolicy.
+  PRESENTERS = {
+    SomeResource  => [SomeResourcePresenter, SomeResourcePolicy],
+    OtherResource => [OtherResourcePresenter, OtherResourcePolicy]
+  }
+
+  class << self
+    def instance
+      @factory ||= Vizier::PresenterFactory.new(PRESENTERS)
+    end
+  end
+end

--- a/spec/vizier/vizier/caching_presenter_config_spec.rb
+++ b/spec/vizier/vizier/caching_presenter_config_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'support/presenter_config_fakes'
+require 'vizier/caching_presenter_config'
+
+RSpec.describe Vizier::CachingPresenterConfig do
+  # These specs all have two equivalent expectations for clarity: that the
+  # config does not give the newly reassigned class through constant lookup.
+
+  describe '#type' do
+    around(:each) do |example|
+      type = resolve_class('FakeType')
+      example.run
+      redefine_class('FakeType', type)
+    end
+
+    it 'caches the class given' do
+      config = build_config
+      type1 = config.type
+      redefine_class('FakeType', OtherFakeType)
+      type2 = config.type
+
+      expect(type1).to eq type2
+      expect(type1).not_to eq OtherFakeType
+    end
+  end
+
+  describe '#presenter' do
+    around(:each) do |example|
+      presenter = resolve_class('FakePresenter')
+      example.run
+      redefine_class('FakePresenter', presenter)
+    end
+
+    it 'caches the class given' do
+      config = build_config
+      presenter1 = config.presenter
+      redefine_class('FakePresenter', OtherFakePresenter)
+      presenter2 = config.presenter
+
+      expect(presenter1).to eq presenter2
+      expect(presenter1).not_to eq OtherFakePresenter
+    end
+  end
+
+  describe '#policy' do
+    around(:each) do |example|
+      policy = resolve_class('FakePolicy')
+      example.run
+      redefine_class('FakePolicy', policy)
+    end
+
+    it 'caches the class given' do
+      config = build_config
+      policy1 = config.policy
+      redefine_class('FakePolicy', OtherFakePolicy)
+      policy2 = config.policy
+
+      expect(policy1).to eq policy2
+      expect(policy1).not_to eq OtherFakePolicy
+    end
+  end
+
+  def build_config
+    described_class.new(FakeType, FakePresenter, FakePolicy)
+  end
+
+  def resolve_class(name)
+    Object.const_get(name)
+  end
+
+  def redefine_class(name, klass)
+    Object.send(:remove_const, name)
+    Object.const_set(name, klass)
+  end
+end

--- a/spec/vizier/vizier/collection_presenter_spec.rb
+++ b/spec/vizier/vizier/collection_presenter_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'vizier/collection_presenter'
+require 'vizier/null_presenter'
+
+RSpec.describe Vizier::CollectionPresenter do
+  context 'with a policy that does not allow any items' do
+    it 'reports empty' do
+      presenter = without_items
+      expect(presenter.empty?).to be true
+    end
+
+    it 'iterates over nothing with .each' do
+      presenter = without_items
+      items = []
+      presenter.each { |item| items << item }
+      expect(items).to be_empty
+    end
+  end
+
+  context 'with a policy granting access to items' do
+    it 'reports not empty' do
+      items = [double(name: 'item1'), double(name: 'item2')]
+      presenter = with_items(items)
+      expect(presenter.empty?).to be false
+    end
+
+    it 'supports .each over the items and presents them' do
+      items = [double(name: 'item1'), double(name: 'item2')]
+      presenter = with_items(items)
+      items = []
+      presenter.each { |item| items << item }
+
+      expect(items).to all be_a(Vizier::NullPresenter)
+    end
+
+    it 'supports .map over items and preserves order' do
+      items = [double(name: 'item1'), double(name: 'item2')]
+      presenter = with_items(items)
+
+      expect(presenter.map(&:name)).to eq(['item1', 'item2'])
+    end
+  end
+
+  def build_presenter(policy)
+    Vizier::CollectionPresenter.new(
+      policy,
+      double('view'),
+      presenter_factory: factory
+    )
+  end
+
+  def factory
+    double('factory').tap do |factory|
+      allow(factory).to receive(:[]) do |resource, user, view|
+        Vizier::NullPresenter.new(resource)
+      end
+    end
+  end
+
+  def without_items
+    policy = double('CollectionPolicy', user: double('user'), resolve: [])
+    build_presenter(policy)
+  end
+
+  def with_items(items)
+    policy = double('CollectionPolicy', user: double('user'), resolve: items)
+    build_presenter(policy)
+  end
+end

--- a/spec/vizier/vizier/null_presenter_spec.rb
+++ b/spec/vizier/vizier/null_presenter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'vizier/null_presenter'
+
+RSpec.describe Vizier::NullPresenter do
+
+  subject(:presenter) { described_class.new(object, double('View')) }
+
+  it 'delegates to the presented object' do
+    expect(presenter.__getobj__).to eq object
+    expect(presenter.foo). to eq 'bar'
+  end
+
+  def object
+    @object ||= double('To Be Presented', foo: 'bar')
+  end
+end

--- a/spec/vizier/vizier/presenter_config_spec.rb
+++ b/spec/vizier/vizier/presenter_config_spec.rb
@@ -1,25 +1,39 @@
 # frozen_string_literal: true
 
-require 'ostruct'
+require 'support/presenter_config_fakes'
 require 'vizier/presenter_config'
 
 RSpec.describe Vizier::PresenterConfig do
-  class Type; end
-  class Presenter < Struct.new(:policy, :view); end
-  class Policy < Struct.new(:user, :object); end
-
   describe '#type' do
     context 'when a class was given' do
       it 'returns it' do
         config = class_config
-        expect(config.type).to eq Type
+        expect(config.type).to eq FakeType
       end
     end
 
     context 'when a string was given' do
       it 'resolves the class' do
+        config = string_config
+        expect(config.type).to eq FakeType
+      end
+    end
+
+    context 'when reloading classes' do
+      around(:each) do |example|
+        type = resolve_class('FakeType')
+        example.run
+        redefine_class('FakeType', type)
+      end
+
+      it 'returns the new class' do
         config = class_config
-        expect(config.type).to eq Type
+        type1 = config.type
+        redefine_class('FakeType', OtherFakeType)
+        type2 = config.type
+
+        expect(type1).not_to eq type2
+        expect(type2).to eq OtherFakeType
       end
     end
   end
@@ -28,14 +42,32 @@ RSpec.describe Vizier::PresenterConfig do
     context 'when a class was given' do
       it 'returns it' do
         config = class_config
-        expect(config.presenter).to eq Presenter
+        expect(config.presenter).to eq FakePresenter
       end
     end
 
     context 'when a string was given' do
       it 'resolves the class' do
+        config = string_config
+        expect(config.presenter).to eq FakePresenter
+      end
+    end
+
+    context 'when reloading classes' do
+      around(:each) do |example|
+        presenter = resolve_class('FakePresenter')
+        example.run
+        redefine_class('FakePresenter', presenter)
+      end
+
+      it 'returns the new class' do
         config = class_config
-        expect(config.presenter).to eq Presenter
+        presenter1 = config.presenter
+        redefine_class('FakePresenter', OtherFakePresenter)
+        presenter2 = config.presenter
+
+        expect(presenter1).not_to eq presenter2
+        expect(presenter2).to eq OtherFakePresenter
       end
     end
   end
@@ -44,14 +76,32 @@ RSpec.describe Vizier::PresenterConfig do
     context 'when a class was given' do
       it 'returns it' do
         config = class_config
-        expect(config.policy).to eq Policy
+        expect(config.policy).to eq FakePolicy
       end
     end
 
     context 'when a string was given' do
       it 'resolves the class' do
+        config = string_config
+        expect(config.policy).to eq FakePolicy
+      end
+    end
+
+    context 'when reloading classes' do
+      around(:each) do |example|
+        policy = resolve_class('FakePolicy')
+        example.run
+        redefine_class('FakePolicy', policy)
+      end
+
+      it 'returns the new class' do
         config = class_config
-        expect(config.policy).to eq Policy
+        policy1 = config.policy
+        redefine_class('FakePolicy', OtherFakePolicy)
+        policy2 = config.policy
+
+        expect(policy1).not_to eq policy2
+        expect(policy2).to eq OtherFakePolicy
       end
     end
   end
@@ -64,11 +114,11 @@ RSpec.describe Vizier::PresenterConfig do
     subject(:presenter) { presenter = class_config.present(object, user, view) }
 
     it 'uses the configured presenter class for the presenter' do
-      expect(presenter).to be_a Presenter
+      expect(presenter).to be_a FakePresenter
     end
 
     it 'uses the configured policy class on the presenter' do
-      expect(presenter.policy).to be_a Policy
+      expect(presenter.policy).to be_a FakePolicy
     end
 
     it 'sets the supplied view on the presenter' do
@@ -85,11 +135,27 @@ RSpec.describe Vizier::PresenterConfig do
     end
   end
 
+  context 'while redefining/reloading classes' do
+    it 'gives the new type' do
+      config = class_config
+      type1 = config.type
+    end
+  end
+
   def class_config
-    described_class.new(Type, Presenter, Policy)
+    described_class.new(FakeType, FakePresenter, FakePolicy)
   end
 
   def string_config
-    described_class.new('Type', 'Presenter', 'Policy')
+    described_class.new('FakeType', 'FakePresenter', 'FakePolicy')
+  end
+
+  def resolve_class(name)
+    Object.const_get(name)
+  end
+
+  def redefine_class(name, klass)
+    Object.send(:remove_const, name)
+    Object.const_set(name, klass)
   end
 end

--- a/spec/vizier/vizier/presenter_config_spec.rb
+++ b/spec/vizier/vizier/presenter_config_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'vizier/presenter_config'
+
+RSpec.describe Vizier::PresenterConfig do
+  class Type; end
+  class Presenter < Struct.new(:policy, :view); end
+  class Policy < Struct.new(:user, :object); end
+
+  describe '#type' do
+    context 'when a class was given' do
+      it 'returns it' do
+        config = class_config
+        expect(config.type).to eq Type
+      end
+    end
+
+    context 'when a string was given' do
+      it 'resolves the class' do
+        config = class_config
+        expect(config.type).to eq Type
+      end
+    end
+  end
+
+  describe '#presenter' do
+    context 'when a class was given' do
+      it 'returns it' do
+        config = class_config
+        expect(config.presenter).to eq Presenter
+      end
+    end
+
+    context 'when a string was given' do
+      it 'resolves the class' do
+        config = class_config
+        expect(config.presenter).to eq Presenter
+      end
+    end
+  end
+
+  describe '#policy' do
+    context 'when a class was given' do
+      it 'returns it' do
+        config = class_config
+        expect(config.policy).to eq Policy
+      end
+    end
+
+    context 'when a string was given' do
+      it 'resolves the class' do
+        config = class_config
+        expect(config.policy).to eq Policy
+      end
+    end
+  end
+
+  describe '#present' do
+    let(:object) { double('Object') }
+    let(:user)   { double('User') }
+    let(:view)   { double('View') }
+
+    subject(:presenter) { presenter = class_config.present(object, user, view) }
+
+    it 'uses the configured presenter class for the presenter' do
+      expect(presenter).to be_a Presenter
+    end
+
+    it 'uses the configured policy class on the presenter' do
+      expect(presenter.policy).to be_a Policy
+    end
+
+    it 'sets the supplied view on the presenter' do
+      expect(presenter.view).to eq view
+    end
+
+    it 'sets the supplied user on the policy' do
+      expect(presenter.policy.user).to eq user
+
+    end
+
+    it 'sets the supplied object on the policy' do
+      expect(presenter.policy.object).to eq object
+    end
+  end
+
+  def class_config
+    described_class.new(Type, Presenter, Policy)
+  end
+
+  def string_config
+    described_class.new('Type', 'Presenter', 'Policy')
+  end
+end

--- a/spec/vizier/vizier/presenter_factory_spec.rb
+++ b/spec/vizier/vizier/presenter_factory_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# See the fakes for usage examples
+require 'support/resource_presenter_fakes'
+require 'vizier/presenter_factory'
+require 'vizier/read_only_policy'
+require 'vizier/null_presenter'
+
+RSpec.describe Vizier::PresenterFactory do
+
+  context 'when not supplying a mapping' do
+    it 'uses the NullPresenter' do
+      factory = default_factory
+      presenter = factory[double('object'), double('user'), double('view')]
+      expect(presenter).to be_a Vizier::NullPresenter
+    end
+
+    it 'wraps the object in a ReadOnlyPolicy' do
+      factory   = default_factory
+      user      = double('user')
+      object    = double('object')
+      presenter = factory[object, user, double('view')]
+      policy    = presenter.__getobj__
+
+      expect(policy).to be_a Vizier::ReadOnlyPolicy
+      expect(policy.user).to eq(user)
+      expect(policy.resource).to eq(object)
+    end
+  end
+
+  # This is more of an integration test to show usage than a unit test.
+  context 'when subclassing for application needs' do
+    context 'when an object type is not mapped' do
+      it 'uses the NullPresenter' do
+        factory = configured_factory
+        presenter = factory[double('object'), double('user'), double('view')]
+        expect(presenter).to be_a Vizier::NullPresenter
+      end
+
+      it 'wraps the object in a ReadOnlyPolicy' do
+        factory   = configured_factory
+        user      = double('user')
+        object    = double('object')
+        presenter = factory[object, user, double('view')]
+        policy    = presenter.__getobj__
+
+        expect(policy).to be_a Vizier::ReadOnlyPolicy
+        expect(policy.user).to eq(user)
+        expect(policy.resource).to eq(object)
+      end
+    end
+
+    describe 'a specific resource presenter' do
+      it 'transforms a property' do
+        # See SomeResourcePresenter, the fake behavior is to upcase name
+        resource = SomeResource.new('a name', double('other resource'))
+        presenter = build_specific_presenter(resource)
+        expect(presenter.name).to eq 'A NAME'
+      end
+
+      it 'allows create?, according to configured policy' do
+        resource = SomeResource.new('a name', double('other resource'))
+        presenter = build_specific_presenter(resource)
+        expect(presenter.create?).to be true
+      end
+
+      describe 'with associated objects' do
+        it 'uses the configured presenter' do
+          other = OtherResource.new('a long title')
+          resource = SomeResource.new('name', other)
+          presenter = build_specific_presenter(resource)
+
+          expect(presenter.other_resource).to be_a(OtherResourcePresenter)
+        end
+
+        it 'presents with transformation methods available' do
+          other = OtherResource.new('a long title')
+          resource = SomeResource.new('name', other)
+          presenter = build_specific_presenter(resource)
+          other_presenter = presenter.other_resource
+
+          expect(other_presenter.short_title).to eq 'a long...'
+        end
+
+        it 'disallows edit?, according to the configured policy' do
+          other = OtherResource.new('a long title')
+          resource = SomeResource.new('name', other)
+          presenter = build_specific_presenter(resource)
+          other_presenter = presenter.other_resource
+
+          expect(other_presenter.edit?).to be false
+        end
+      end
+    end
+  end
+
+  def default_factory
+    Vizier::PresenterFactory.new
+  end
+
+  def configured_factory
+    FakePresenterFactory.instance
+  end
+
+  def build_specific_presenter(resource)
+    policy = SomeResourcePolicy.new(double('User'), resource)
+    SomeResourcePresenter.new(policy, double('View'))
+  end
+
+  def build_generic_presenter(resource)
+    policy = double('policy', resource: resource)
+    AppResourcePresenter.new(policy, double('View'))
+  end
+end

--- a/spec/vizier/vizier/read_only_policy_spec.rb
+++ b/spec/vizier/vizier/read_only_policy_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'vizier/read_only_policy'
+
+RSpec.describe Vizier::ReadOnlyPolicy do
+
+  subject(:policy) { described_class.new(double('User'), double('Resource')) }
+
+  it 'allows show?' do
+    expect(policy.show?).to be true
+  end
+
+  it 'does not raise on authorize! :show?' do
+    expect { policy.authorize! :show? }.not_to raise_exception
+  end
+end

--- a/spec/vizier/vizier/resource_presenter_spec.rb
+++ b/spec/vizier/vizier/resource_presenter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'vizier/resource_presenter'
+
+RSpec.describe Vizier::ResourcePresenter do
+  it 'delegates to the resource' do
+    presenter = build_presenter
+    expect(presenter.name).to be 'a name'
+  end
+
+  def build_presenter
+    resource = double('Resource', name: 'a name')
+    policy   = double('Policy', resource: resource)
+    view     = double('View')
+    described_class.new(policy, view, presenter_factory: double())
+  end
+end


### PR DESCRIPTION
There are a few things going on in this pull request, most of which are documented pretty well in the commit messages. The highlights are:

 * Adding convenience for auto-presenting items based on configuration given to a factory
 * Extracting the base presenter support, which will likely become the Vizier gem
 * Adding full test coverage for Vizier
 * Setting up Canister for system-wide services

At this point, I think all of the basic needs are covered for plumbing the presenters and policies through controllers and views concisely and consistently. The UI yak has been shaved.