### PR TITLE
Integrate swapmeet with keycard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/mlibrary/keycard.git
-  revision: 2bfa6965583fc2e1a3edee0ef596252749bb53e9
+  revision: 00573e5a8b011e42ab51ff7f86837443c00766bd
   specs:
     keycard (0.1.0)
       mysql2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,7 @@ class ApplicationController < ActionController::Base
     def current_user
       unless defined?(@current_user)
         @current_user = user_from_session || User.guest
+        @current_user.identity = Keycard::RequestAttributes.new(request)
       end
       @current_user
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   has_many :listings, foreign_key: :owner
 
+  attr_accessor :identity
+
   def self.nobody
     new(username: '<nobody>', display_name: '(No one)', email: '').tap(&:readonly!)
   end

--- a/app/resolvers/agent_resolver.rb
+++ b/app/resolvers/agent_resolver.rb
@@ -1,4 +1,6 @@
-require 'checkpoint/agent' 
+# frozen_string_literal: true
+
+require 'checkpoint/agent'
 require 'ostruct'
 
 class AgentResolver < Checkpoint::Agent::Resolver
@@ -7,8 +9,8 @@ class AgentResolver < Checkpoint::Agent::Resolver
   end
 
   def resolve(actor)
-    super + actor.identity.all.map { |k,v| agents_for(k,v) }.flatten
-  end 
+    super + actor.identity.all.map { |k, v| agents_for(k, v) }.flatten
+  end
 
   def agents_for(attribute, values)
     [ values ].flatten.map do |value|
@@ -18,6 +20,5 @@ class AgentResolver < Checkpoint::Agent::Resolver
 
   private
 
-  attr_reader :agent_factory
-
+    attr_reader :agent_factory
 end

--- a/app/resolvers/agent_resolver.rb
+++ b/app/resolvers/agent_resolver.rb
@@ -1,0 +1,23 @@
+require 'checkpoint/agent' 
+require 'ostruct'
+
+class AgentResolver < Checkpoint::Agent::Resolver
+  def initialize(agent_factory: Checkpoint::Agent)
+    @agent_factory = agent_factory
+  end
+
+  def resolve(actor)
+    super + actor.identity.all.map { |k,v| agents_for(k,v) }.flatten
+  end 
+
+  def agents_for(attribute, values)
+    [ values ].flatten.map do |value|
+      agent_factory.from(OpenStruct.new(agent_type: attribute, agent_id: value))
+    end
+  end
+
+  private
+
+  attr_reader :agent_factory
+
+end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -17,4 +17,4 @@ Services.register(:presenters) {
   Vizier::PresenterFactory.new(PRESENTERS, config_type: config_class)
 }
 
-Services.register(:checkpoint) { Checkpoint::Authority.new }
+Services.register(:checkpoint) { Checkpoint::Authority.new(agent_resolver: AgentResolver.new) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ApplicationController do
+RSpec.describe ApplicationController, type: :controller do
   context 'rescue_from exception' do
     controller do
       attr_accessor :the_exception
@@ -22,16 +22,10 @@ RSpec.describe ApplicationController do
 
   context 'user identity' do
 
-    INST_ID = 1
-    NETWORK = "10.0.0.0/16"
-
-    before(:all) do
-      range = IPAddr.new(NETWORK).to_range
-    end
-
+    # because testing rails controllers is messy, ApplicationController even
+    # more so
     controller do
       def something
-        request.set_header('X-Forwarded-For',"10.0.0.1")
         render body: nil
       end
 
@@ -41,26 +35,13 @@ RSpec.describe ApplicationController do
     end
 
     before do
-      range = IPAddr.new(NETWORK).to_range
-      Keycard::DB[:aa_network].insert([1, nil, NETWORK, range.first.to_i, range.last.to_i,
-                                       'allow', nil, INST_ID, Time.now.utc, 'test', 'f'])
       routes.draw { get "something" => "anonymous#something" }
     end
 
-    after do
-      Keycard::DB[:aa_network].delete
-    end
-
-    it "adds institutional identity when constructing the current_user" do
+    it "adds identity that responds to #all when constructing the current_user" do
       get :something
 
-      expect(controller.identity["dlpsInstitutionIds"]).to contain_exactly(INST_ID)
-    end
-
-    it "adds identity when constructing the current_user" do
-      get :something
-
-      expect(controller.identity).not_to be_nil
+      expect(controller.identity).to respond_to(:all)
     end
 
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -19,4 +19,49 @@ RSpec.describe ApplicationController do
       expect(response).to be_unauthorized
     end
   end
+
+  context 'user identity' do
+
+    INST_ID = 1
+    NETWORK = "10.0.0.0/16"
+
+    before(:all) do
+      range = IPAddr.new(NETWORK).to_range
+    end
+
+    controller do
+      def something
+        request.set_header('X-Forwarded-For',"10.0.0.1")
+        render body: nil
+      end
+
+      def identity
+        current_user.identity
+      end
+    end
+
+    before do
+      range = IPAddr.new(NETWORK).to_range
+      Keycard::DB[:aa_network].insert([1, nil, NETWORK, range.first.to_i, range.last.to_i,
+                                       'allow', nil, INST_ID, Time.now.utc, 'test', 'f'])
+      routes.draw { get "something" => "anonymous#something" }
+    end
+
+    after do
+      Keycard::DB[:aa_network].delete
+    end
+
+    it "adds institutional identity when constructing the current_user" do
+      get :something
+
+      expect(controller.identity["dlpsInstitutionIds"]).to contain_exactly(INST_ID)
+    end
+
+    it "adds identity when constructing the current_user" do
+      get :something
+
+      expect(controller.identity).not_to be_nil
+    end
+
+  end
 end

--- a/spec/integration/inst_permit_spec.rb
+++ b/spec/integration/inst_permit_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+require_relative '../support/checkpoint_helpers'
+
+RSpec.describe "permitting an institution to a resource" do
+
+  def checkpoint_permits?(user,action)
+    Checkpoint::Query::ActionPermitted.new(user, action, Checkpoint::Resource.all, 
+                                           authority: Services.checkpoint).true?
+  end
+
+  def add_inst_network(inst:, network:, access:)
+    @unique_id ||= 0
+    @unique_id += 1
+    range = IPAddr.new(network).to_range
+    Keycard::DB[:aa_network].insert([@unique_id, nil, network, range.first.to_i, range.last.to_i,
+                                     access.to_s, nil, inst, Time.now.utc, 'test', 'f'])
+
+  end
+
+  let(:request) { double(:request) }
+  let(:action) { "view" }
+  let(:user) { User.guest } 
+
+  before(:each) do 
+    add_inst_network(inst: 1, network: '10.0.1.0/24', access: "allow")
+    add_inst_network(inst: 2, network: '10.0.2.0/24', access: "allow")
+    new_permit(agent(type: 'dlpsInstitutionId', id: '1'),
+               make_permission(action), 
+               all_resources).save
+
+    allow(request).to receive(:get_header)
+      .with('X-Forwarded-For')
+      .and_return(client_ip)
+
+    user.identity = Keycard::RequestAttributes.new(request)
+  end
+
+  after(:each) do
+    Keycard::DB[:aa_network].delete
+  end
+
+  context "with an ip address mapping to an allowed institution" do
+    let(:client_ip) { "10.0.1.1" }
+
+    it "permits the user to view anything" do
+      expect(checkpoint_permits?(user, action)).to be(true)
+    end
+  end
+
+  context "with an ip address that does not map to an institution" do
+    let(:client_ip) { "10.0.3.1" }
+
+    it "does not permit the user to view anything" do
+      expect(checkpoint_permits?(user, action)).to be(false)
+    end
+  end
+
+  context "with an ip address that maps to an institution that is not allowed" do
+    let(:client_ip) { "10.0.2.1" }
+
+    it "does not permit the user to view anything" do
+      expect(checkpoint_permits?(user, action)).to be(false)
+    end
+  end
+end

--- a/spec/integration/inst_permit_spec.rb
+++ b/spec/integration/inst_permit_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require_relative '../support/checkpoint_helpers'
 
 RSpec.describe "permitting an institution to a resource" do
 
-  def checkpoint_permits?(user,action)
-    Checkpoint::Query::ActionPermitted.new(user, action, Checkpoint::Resource.all, 
+  def checkpoint_permits?(user, action)
+    Checkpoint::Query::ActionPermitted.new(user, action, Checkpoint::Resource.all,
                                            authority: Services.checkpoint).true?
   end
 
@@ -14,18 +16,17 @@ RSpec.describe "permitting an institution to a resource" do
     range = IPAddr.new(network).to_range
     Keycard::DB[:aa_network].insert([@unique_id, nil, network, range.first.to_i, range.last.to_i,
                                      access.to_s, nil, inst, Time.now.utc, 'test', 'f'])
-
   end
 
   let(:request) { double(:request) }
   let(:action) { "view" }
-  let(:user) { User.guest } 
+  let(:user) { User.guest }
 
-  before(:each) do 
+  before(:each) do
     add_inst_network(inst: 1, network: '10.0.1.0/24', access: "allow")
     add_inst_network(inst: 2, network: '10.0.2.0/24', access: "allow")
     new_permit(agent(type: 'dlpsInstitutionId', id: '1'),
-               make_permission(action), 
+               make_permission(action),
                all_resources).save
 
     allow(request).to receive(:get_header)

--- a/spec/policies/listing_policy_spec.rb
+++ b/spec/policies/listing_policy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/checkpoint_helpers'
 
 RSpec.describe ListingPolicy do
   subject { policy }
@@ -105,29 +106,4 @@ RSpec.describe ListingPolicy do
     end
   end
 
-  def new_permit(agent, credential, resource, zone: Checkpoint::DB::Permit.default_zone)
-    Checkpoint::DB::Permit.from(agent, credential, resource, zone: zone)
-  end
-
-  def agent(type: 'user', id: 'userid')
-    actor = double('actor', agent_type: type, id: id)
-    Checkpoint::Agent.new(actor)
-  end
-
-  def make_role(name)
-    Checkpoint::Credential::Role.new(name)
-  end
-
-  def make_permission(name)
-    Checkpoint::Credential::Permission.new(name)
-  end
-
-  def all_resources
-    Checkpoint::Resource.all
-  end
-
-  def resource(type: 'resource', id: 1)
-    entity = double('entity', resource_type: type, id: id)
-    Checkpoint::Resource.from(entity)
-  end
 end

--- a/spec/policies/listing_policy_spec.rb
+++ b/spec/policies/listing_policy_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe ListingPolicy do
   let(:listing)       { create(:listing, owner: listing_owner) }
   let(:listing_owner) { double('Listing Owner') }
 
+  before(:each) do 
+    user.identity = double(:identity, all: {})
+  end
+
   context "when user is a guest" do
     let(:user) { User.guest }
     let(:listing_owner) { other_user }

--- a/spec/policies/listing_policy_spec.rb
+++ b/spec/policies/listing_policy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ListingPolicy do
   let(:listing)       { create(:listing, owner: listing_owner) }
   let(:listing_owner) { double('Listing Owner') }
 
-  before(:each) do 
+  before(:each) do
     user.identity = double(:identity, all: {})
   end
 
@@ -62,7 +62,7 @@ RSpec.describe ListingPolicy do
       expect(policy.update?).to be true
     end
     after do
-      Checkpoint::DB::db[:permits].delete
+      Checkpoint::DB.db[:permits].delete
     end
   end
 

--- a/spec/resolvers/agent_resolver_spec.rb
+++ b/spec/resolvers/agent_resolver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "agent_resolver"
 
 module Swapmeet
@@ -6,7 +8,7 @@ module Swapmeet
       described_class.new()
     end
 
-    def fake_attrs(attrs) 
+    def fake_attrs(attrs)
       double(:attrs, all: attrs)
     end
 
@@ -15,7 +17,7 @@ module Swapmeet
     end
 
     describe "#resolve" do
-      let(:actor) { double(:user, identity: attrs ) }
+      let(:actor) { double(:user, identity: attrs) }
       let(:base_agent) { Checkpoint::Agent.from(actor) }
 
       context "with some attributes" do
@@ -28,7 +30,7 @@ module Swapmeet
 
         it "turns the attributes into agents" do
           resolved_agents = agent_resolver.resolve(actor)
-          expect(resolved_agents).to contain_exactly(base_agent,agent)
+          expect(resolved_agents).to contain_exactly(base_agent, agent)
         end
       end
 
@@ -38,7 +40,7 @@ module Swapmeet
 
         it "turns the attributes into agents" do
           resolved_agents = agent_resolver.resolve(actor)
-          expect(resolved_agents).to contain_exactly(base_agent,agent)
+          expect(resolved_agents).to contain_exactly(base_agent, agent)
         end
       end
 
@@ -47,7 +49,7 @@ module Swapmeet
         let(:agents) do
           [ base_agent,
             agent_from(type: 'foo', id: 'bar'),
-            agent_from(type: 'foo', id: 'baz') ] 
+            agent_from(type: 'foo', id: 'baz') ]
         end
 
         it "returns two agents" do

--- a/spec/resolvers/agent_resolver_spec.rb
+++ b/spec/resolvers/agent_resolver_spec.rb
@@ -1,0 +1,63 @@
+require "agent_resolver"
+
+module Swapmeet
+  RSpec.describe AgentResolver do
+    subject(:agent_resolver) do
+      described_class.new()
+    end
+
+    def fake_attrs(attrs) 
+      double(:attrs, all: attrs)
+    end
+
+    def agent_from(type:, id:)
+      Checkpoint::Agent.from(OpenStruct.new(agent_type: type, agent_id: id))
+    end
+
+    describe "#resolve" do
+      let(:actor) { double(:user, identity: attrs ) }
+      let(:base_agent) { Checkpoint::Agent.from(actor) }
+
+      context "with some attributes" do
+        subject(:agent_resolver) do
+          described_class.new()
+        end
+
+        let(:attrs) { fake_attrs("foo" => "bar") }
+        let(:agent) { agent_from(type: "foo", id: "bar") }
+
+        it "turns the attributes into agents" do
+          resolved_agents = agent_resolver.resolve(actor)
+          expect(resolved_agents).to contain_exactly(base_agent,agent)
+        end
+      end
+
+      context "with some different attributes" do
+        let(:attrs) { fake_attrs("baz" => "quux") }
+        let(:agent) { agent_from(type: 'baz', id: 'quux') }
+
+        it "turns the attributes into agents" do
+          resolved_agents = agent_resolver.resolve(actor)
+          expect(resolved_agents).to contain_exactly(base_agent,agent)
+        end
+      end
+
+      context "with a multi-value attribute" do
+        let(:attrs) { fake_attrs("foo" => ['bar', 'baz']) }
+        let(:agents) do
+          [ base_agent,
+            agent_from(type: 'foo', id: 'bar'),
+            agent_from(type: 'foo', id: 'baz') ] 
+        end
+
+        it "returns two agents" do
+          resolved_agents = agent_resolver.resolve(actor)
+          expect(resolved_agents.length).to eq(agents.length)
+          expect(resolved_agents).to contain_exactly(*agents)
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/support/checkpoint_helpers.rb
+++ b/spec/support/checkpoint_helpers.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 def new_permit(agent, credential, resource, zone: Checkpoint::DB::Permit.default_zone)
   Checkpoint::DB::Permit.from(agent, credential, resource, zone: zone)
 end

--- a/spec/support/checkpoint_helpers.rb
+++ b/spec/support/checkpoint_helpers.rb
@@ -1,0 +1,26 @@
+
+def new_permit(agent, credential, resource, zone: Checkpoint::DB::Permit.default_zone)
+  Checkpoint::DB::Permit.from(agent, credential, resource, zone: zone)
+end
+
+def agent(type: 'user', id: 'userid')
+  actor = double('actor', agent_type: type, id: id)
+  Checkpoint::Agent.new(actor)
+end
+
+def make_role(name)
+  Checkpoint::Credential::Role.new(name)
+end
+
+def make_permission(name)
+  Checkpoint::Credential::Permission.new(name)
+end
+
+def all_resources
+  Checkpoint::Resource.all
+end
+
+def resource(type: 'resource', id: 1)
+  entity = double('entity', resource_type: type, id: id)
+  Checkpoint::Resource.from(entity)
+end


### PR DESCRIPTION
- Adds the keycard user attributes on `User#identity`

- Adds an `AgentResolver` that connects the Keycard attributes to the Checkpoint world of agents - this will eventually likely be extracted elsewhere, and the current `OpenStruct`-based shim will likely turn into a real top-level concept

- Adds an example (as an integration test) of creating and checking a permit based on institutional affiliation.